### PR TITLE
0.0.4 - Adds targets/publishToOrgRoot.sh and targets/publishAllToOrgRoot.sh to support publishing to a top-level GitHub org's GitHub Pages site.

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,5 +108,7 @@ Mostly links to the software used
 0.0.1 - Initial version of a multi-target Jekyll-based blog. Includes clean-blog, minimal-mistakes, and stylish-portfolio themes.
 0.0.2 - Adds sparrow and alembic target themes. Improve publishAll.sh to add .nojekyll to root. Improve sync.sh to handle missing _theme_assets or _theme_pages dirs, and to handle _theme_posts dir. Replace use of Plotly example with P5JS example. Add /autoplay to some playables. Adds _includes/smartdown_header.html override file. Adjusts where smartdown-outer-container div is inserted in various themes, and adjust its width to match the theme's responsive layout.
 0.0.3 - Amends .gitignore to filter .hide and .deleteme suffixes, and targets/legacy/_sass/. Fixes build.sh to allow for - and . in repo names. Add syncThemeChanges() to serve.sh so that the _theme_XYZ directories are watched and synced. Adds targets/legacy/install.sh to targets/legacy and removes the corresponding assets (_sass/font-awesome/ and _sass/bootstrap-sass/) from the repo. targets/legacy/install.sh must be run once after this repo is downloaded to restore these assets.
+0.0.4 - Adds targets/publishToOrgRoot.sh and targets/publishAllToOrgRoot.sh to support publishing to a top-level GitHub org's GitHub Pages site.
+
 
 

--- a/_pages/About.md
+++ b/_pages/About.md
@@ -9,7 +9,7 @@ background: '/img/bg-about.jpg'
 
 This is a [GitHub Pages](https://pages.github.com)-based blog that utilizes the Jekyll services provided by GitHub, and optionally enables some posts and pages to utilize Smartdown, an in-browser renderer of enhanced Markdown and a reactive runtime.
 
-The source for this site is at [smartdown/blog-kit](https://github.com/smartdown/blog-kit/) (v0.0.3).
+The source for this site is at [smartdown/blog-kit](https://github.com/smartdown/blog-kit/) (v0.0.4.2).
 
 ### About the Author
 

--- a/targets/build.sh
+++ b/targets/build.sh
@@ -1,12 +1,6 @@
-# build.sh targetName [optionalBaseSuffix]
+# build.sh targetName [optionalBaseUrl] [optionalRemote]
 #
 #
-
-baseUrl="/"
-REMOTE=`git remote get-url --push origin`
-if [[ $REMOTE =~ ^([^/]+)/([[:alpha:]\.\-]+)\.git$ ]]; then
-	baseUrl="/${BASH_REMATCH[2]}"
-fi
 
 export here=${0%/*}
 if [ "$1" == "" ]; then
@@ -14,11 +8,23 @@ if [ "$1" == "" ]; then
     exit 1
 fi
 
+remoteRepo=`git remote get-url --push origin`
 export targetName="${1}"
 export target="${here}/${targetName}"
 
-if [ "$2" != "" ]; then
-	baseUrl="${baseUrl}/$2"
+if [[ $remoteRepo =~ ^([^/]+)/([[:alpha:]\.\-]+)\.git$ ]]; then
+	baseUrl="/${BASH_REMATCH[2]}"
+else
+	echo "# Unable to compute baseUrl from remoteRepo: $remoteRepo"
+	exit 1
+fi
+
+if [[ $# -gt 1 ]]; then
+	baseUrl="${2}"
+
+	if [ "$3" != "" ]; then
+		remoteRepo="${3}"
+	fi
 fi
 
 if [[ ! -d ${target} ]]; then
@@ -31,6 +37,11 @@ ${here}/sync.sh ${targetName}
 
 cd ${target}
 
+baseUrlOption=""
+if [ "$baseUrl" != "" ]; then
+	baseUrlOption="--baseurl=${baseUrl}"
+fi
+
 # Prepare build directory
 rm -rf _site
 mkdir _site
@@ -38,7 +49,7 @@ mkdir _site
 bundle exec jekyll build \
 	--config=_config.yml \
 	--destination=_site \
-	--baseurl=${baseUrl}
+	${baseUrlOption}
 
 # Amend the built _site
 touch _site/.nojekyll

--- a/targets/legacy/install.sh
+++ b/targets/legacy/install.sh
@@ -6,4 +6,3 @@ rm -rf _sass
 mkdir _sass
 cp -r node_modules/font-awesome/scss/ ./_sass/font-awesome
 cp -r node_modules/bootstrap-sass/assets/stylesheets/ _sass/bootstrap-sass/
-diff -r _sass _sass.deleteme

--- a/targets/publishAll.sh
+++ b/targets/publishAll.sh
@@ -1,11 +1,18 @@
 export here=${0%/*}
-REMOTE=`git remote get-url --push origin`
+remoteRepo=`git remote get-url --push origin`
 
-${here}/build.sh cb cb
-${here}/build.sh legacy legacy
-${here}/build.sh mm mm
-${here}/build.sh alembic alembic
-${here}/build.sh sparrow sparrow
+if [[ $remoteRepo =~ ^([^/]+)/([[:alpha:]\.\-]+)\.git$ ]]; then
+	rootUrl="/${BASH_REMATCH[2]}"
+else
+	echo "# Unable to compute rootUrl from remoteRepo: $remoteRepo"
+	exit 1
+fi
+
+${here}/build.sh cb ${rootUrl}/cb
+${here}/build.sh legacy ${rootUrl}/legacy
+${here}/build.sh mm ${rootUrl}/mm
+${here}/build.sh alembic ${rootUrl}/alembic
+${here}/build.sh sparrow ${rootUrl}/sparrow
 
 blogRoots="/tmp/blogRoots"
 
@@ -17,6 +24,7 @@ cp -r ${here}/legacy/_site/ ${blogRoots}/legacy
 cp -r ${here}/mm/_site/ ${blogRoots}/mm
 cp -r ${here}/alembic/_site/ ${blogRoots}/alembic
 cp -r ${here}/sparrow/_site/ ${blogRoots}/sparrow
+
 cp ${here}/index.html ${blogRoots}/index.html
 touch ${blogRoots}/.nojekyll
 
@@ -25,5 +33,5 @@ cd ${blogRoots}
 git init
 git add .
 git commit -m "Initial commit"
-git remote add origin ${REMOTE}
+git remote add origin ${remoteRepo}
 git push --force origin master:gh-pages

--- a/targets/publishAllToOrgRoot.sh
+++ b/targets/publishAllToOrgRoot.sh
@@ -1,0 +1,43 @@
+# publishAllToOrgRoot.sh
+
+export here=${0%/*}
+
+remoteRepo=`git remote get-url --push origin`
+if [[ $remoteRepo =~ ^([^:]+):([^/]+)/([[:alpha:]\.\-]+)\.git$ ]]; then
+	echo "BASH_REMATCH: ${BASH_REMATCH[2]} ...  ${BASH_REMATCH[3]}"
+	ghPrefix=${BASH_REMATCH[1]}
+	orgName=${BASH_REMATCH[2]}
+	orgRemoteRepo="${ghPrefix}:${orgName}/${orgName}.github.io.git"
+else
+	echo "# Unable to compute baseUrl from remoteRepo: $remoteRepo"
+	exit 1
+fi
+
+
+${here}/build.sh cb /cb
+${here}/build.sh legacy /legacy
+${here}/build.sh mm /mm
+${here}/build.sh alembic /alembic
+${here}/build.sh sparrow /sparrow
+
+blogRoots="/tmp/blogRoots"
+
+rm -rf ${blogRoots}
+mkdir -p ${blogRoots}
+
+cp -r ${here}/cb/_site/ ${blogRoots}/cb
+cp -r ${here}/legacy/_site/ ${blogRoots}/legacy
+cp -r ${here}/mm/_site/ ${blogRoots}/mm
+cp -r ${here}/alembic/_site/ ${blogRoots}/alembic
+cp -r ${here}/sparrow/_site/ ${blogRoots}/sparrow
+
+cp ${here}/index.html ${blogRoots}/index.html
+touch ${blogRoots}/.nojekyll
+
+cd ${blogRoots}
+
+git init
+git add .
+git commit -m "Initial commit"
+git remote add origin ${orgRemoteRepo}
+git push --force origin master:master

--- a/targets/publishToOrgRoot.sh
+++ b/targets/publishToOrgRoot.sh
@@ -1,6 +1,18 @@
-remoteRepo=`git remote get-url --push origin`
+# publishToOrgRoot.sh targetName
 
 export here=${0%/*}
+
+remoteRepo=`git remote get-url --push origin`
+if [[ $remoteRepo =~ ^([^:]+):([^/]+)/([[:alpha:]\.\-]+)\.git$ ]]; then
+	echo "BASH_REMATCH: ${BASH_REMATCH[2]} ...  ${BASH_REMATCH[3]}"
+	ghPrefix=${BASH_REMATCH[1]}
+	orgName=${BASH_REMATCH[2]}
+	orgRemoteRepo="${ghPrefix}:${orgName}/${orgName}.github.io.git"
+else
+	echo "# Unable to compute baseUrl from remoteRepo: $remoteRepo"
+	exit 1
+fi
+
 if [ "$1" == "" ]; then
     echo "# $0 usage: $0 targetName"
     exit 1
@@ -20,7 +32,7 @@ ${here}/sync.sh ${targetName}
 blogRoots="/tmp/blogRoots"
 dist="${blogRoots}/${targetName}"
 
-${here}/build.sh ${targetName}
+${here}/build.sh ${targetName} "" ${orgRemote}
 
 mkdir -p ${blogRoots}
 rm -rf ${blogRoots}/.git
@@ -33,5 +45,5 @@ cd ${dist}
 git init
 git add .
 git commit -m "Initial commit"
-git remote add origin ${remoteRepo}
-git push --force origin master:gh-pages
+git remote add origin ${orgRemoteRepo}
+git push --force origin master:master


### PR DESCRIPTION
0.0.4
- Adds targets/publishToOrgRoot.sh and targets/publishAllToOrgRoot.sh to support publishing to a top-level GitHub org's GitHub Pages site.